### PR TITLE
Remove JSON indentation to decrease output file size

### DIFF
--- a/Dosai/Dosai.cs
+++ b/Dosai/Dosai.cs
@@ -16,7 +16,6 @@ public static class Dosai
 {
     private static readonly JsonSerializerOptions options = new()
     {
-        WriteIndented = true,
         Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
         DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
     };


### PR DESCRIPTION
To address large file size output. https://github.com/owasp-dep-scan/dosai/issues/12
Testing yields the following improvements:

- Before (351 KB)       >>> After (242 KB)
- Before (3137 KB)     >>> After (2360 KB)
- Before (35 KB)         >>> After (25 KB)
- Before (111721 KB) >>> After (85563 KB)
