### PR TITLE
Adds assembly version info for any DLL located in the search path

### DIFF
--- a/Dosai/AssemblyInformation.cs
+++ b/Dosai/AssemblyInformation.cs
@@ -1,0 +1,7 @@
+namespace Depscan;
+
+public class AssemblyInformation
+{
+    public string? Name { get; set; }
+    public string? Version { get; set; }
+}

--- a/Dosai/MethodsSlice.cs
+++ b/Dosai/MethodsSlice.cs
@@ -7,4 +7,6 @@ public class MethodsSlice
 	public List<Method>? Methods { get; set; }
 
 	public List<MethodCalls>? MethodCalls { get; set; }
+
+	public List<AssemblyInformation>? AssemblyInformation { get; set; }
 }


### PR DESCRIPTION
Will pull the version numbers off any DLL files located in the search path and provide in the Dosai output.

@prabhu the response to the existing methods call of Dosai will now contain a section looking like the following:
  "AssemblyInformation": [
    {
      "Name": "ConsoleApp2",
      "Version": "1.0.0.0"
    },
    {
      "Name": "Microsoft.CSharp",
      "Version": "4.0.0.0"
    },
    {
      "Name": "Newtonsoft.Json",
      "Version": "13.0.0.0"
    },
    {
      "Name": "System.Core",
      "Version": "4.0.0.0"
    },
    {
      "Name": "System.Data.DataSetExtensions",
      "Version": "4.0.0.0"
    },
    {
      "Name": "System.Data",
      "Version": "4.0.0.0"
    },
    {
      "Name": "System",
      "Version": "4.0.0.0"
    },
    {
      "Name": "System.Net.Http",
      "Version": "4.2.0.0"
    },
    {
      "Name": "System.Xml",
      "Version": "4.0.0.0"
    },
    {
      "Name": "System.Xml.Linq",
      "Version": "4.0.0.0"
    }
  ]