### PR TITLE
Assembly inspection to provide the exact assembly version

### DIFF
--- a/Dosai/Dosai.cs
+++ b/Dosai/Dosai.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
+using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
 using System.Text.Json;
@@ -57,10 +58,12 @@ public static class Dosai
                     continue;
                 }
 
+                var fileVersionInfo = FileVersionInfo.GetVersionInfo(assemblyFilePath);
+
                 var assemblyInfo = new AssemblyInformation
                 {
                     Name = fileName,
-                    Version = AssemblyName.GetAssemblyName(assemblyFilePath)?.Version?.ToString()
+                    Version = $"{fileVersionInfo.FileMajorPart}.{fileVersionInfo.FileMinorPart}.{fileVersionInfo.FileBuildPart}.{fileVersionInfo.FilePrivatePart}"
                 };
 
                 assemblyInformation.Add(assemblyInfo);

--- a/Dosai/Dosai.cs
+++ b/Dosai/Dosai.cs
@@ -59,11 +59,15 @@ public static class Dosai
                 }
 
                 var fileVersionInfo = FileVersionInfo.GetVersionInfo(assemblyFilePath);
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+                var buildPart = fileVersionInfo.FileBuildPart == null ? string.Empty : $".{fileVersionInfo.FileBuildPart}";
+                var privatePart = fileVersionInfo.FilePrivatePart == null ? string.Empty : $".{fileVersionInfo.FilePrivatePart}";
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
                 var assemblyInfo = new AssemblyInformation
                 {
                     Name = fileName,
-                    Version = $"{fileVersionInfo.FileMajorPart}.{fileVersionInfo.FileMinorPart}.{fileVersionInfo.FileBuildPart}.{fileVersionInfo.FilePrivatePart}"
+                    Version = $"{fileVersionInfo.FileMajorPart}.{fileVersionInfo.FileMinorPart}{buildPart}{privatePart}"
                 };
 
                 assemblyInformation.Add(assemblyInfo);

--- a/Dosai/Dosai.csproj
+++ b/Dosai/Dosai.csproj
@@ -9,7 +9,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
-    <Version>0.1.2</Version>
+    <Version>0.1.3</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Addresses an issue where the versioning provided is just AssemblyVersion and not specific enough. Version provided now is the exact version down to the build number.