### PR TITLE
Metadata token links. Support for generics.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Test
         run: |
           dotnet test
-          dotnet run --project ./Dosai/ methods --path ./Dosai/Dosai.cs
+          dotnet run --project ./Dosai/ methods --path ./Dosai
   build:
     runs-on: ubuntu-latest
     permissions:
@@ -58,7 +58,7 @@ jobs:
     - name: Test
       run: |
         dotnet test
-        dotnet run --project ./Dosai/ methods --path ./Dosai/Dosai.cs
+        dotnet run --project ./Dosai/ methods --path ./Dosai
     - name: Publish binaries
       run: |
         dotnet publish ./Dosai/ -r linux-x64 --property:PublishDir=dosai-linux -p:PublishSingleFile=true --self-contained false /p:UseAppHost=true /p:AssemblyName=Dosai

--- a/Dosai.TestData/HelloWorld.cs
+++ b/Dosai.TestData/HelloWorld.cs
@@ -1,9 +1,16 @@
 using System.Globalization;
 using System.Reflection;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 
 namespace HelloWorld
 {
+    // Generic interface
+    public interface IGenericInterface<T>
+    {
+        T Process(T item);
+    }
+
     public interface ITestInterface
     {
         void InterfaceMethod();
@@ -18,6 +25,45 @@ namespace HelloWorld
     {
         public virtual void BaseMethod()
         {
+        }
+    }
+
+    // Generic class implementing a generic interface
+    public class GenericProcessor<T> : IGenericInterface<T>
+    {
+        public T Value { get; set; }
+
+        public GenericProcessor(T value)
+        {
+            Value = value;
+        }
+
+        public T Process(T item)
+        {
+            return item;
+        }
+
+        // Generic method within a generic class
+        public TResult ConvertTo<TResult>(T input)
+        {
+            return (TResult)(object)input;
+        }
+    }
+
+    // Non-generic class with a generic method
+    public class Utility
+    {
+        public static T GetDefault<T>()
+        {
+            return default(T);
+        }
+
+        // Generic method with constraints
+        public static void Swap<T>(ref T a, ref T b) where T : class
+        {
+            T temp = a;
+            a = b;
+            b = temp;
         }
     }
 
@@ -39,6 +85,12 @@ namespace HelloWorld
 
         public override void BaseMethod()
         {
+        }
+
+        // Instance method using generics
+        public List<string> GetNames()
+        {
+            return new List<string> { "Alice", "Bob" };
         }
     }
 

--- a/Dosai/ConstructorInfo.cs
+++ b/Dosai/ConstructorInfo.cs
@@ -18,4 +18,7 @@ public class ConstructorInfo
     public bool IsStatic { get; set; }
     public string? BaseType { get; set; }
     public List<string>? ImplementedInterfaces { get; set; }
+    public int MetadataToken { get; set; }
+    public bool IsGenericMethod { get; set; }
+    public List<string>? GenericParameters { get; set; }
 }

--- a/Dosai/EventInfo.cs
+++ b/Dosai/EventInfo.cs
@@ -16,4 +16,6 @@ public class EventInfo
     public List<CustomAttributeInfo>? CustomAttributes { get; set; }
     public string? BaseType { get; set; }
     public List<string>? ImplementedInterfaces { get; set; }
+    public int MetadataToken { get; set; }
+    public string? TypeFullName { get; set; }
 }

--- a/Dosai/FieldInfo.cs
+++ b/Dosai/FieldInfo.cs
@@ -16,4 +16,6 @@ public class FieldInfo
     public List<CustomAttributeInfo>? CustomAttributes { get; set; }
     public string? BaseType { get; set; }
     public List<string>? ImplementedInterfaces { get; set; }
+    public int MetadataToken { get; set; }
+    public string? TypeFullName { get; set; }
 }

--- a/Dosai/Method.cs
+++ b/Dosai/Method.cs
@@ -17,4 +17,10 @@ public class Method
     public List<CustomAttributeInfo>? CustomAttributes { get; set; }
     public string? BaseType { get; set; }
     public List<string>? ImplementedInterfaces { get; set; }
+    public int MetadataToken { get; set; }
+    public string? SourceSignature { get; set; }
+    public string? AssemblySignature { get; set; }
+    public bool IsGenericMethod { get; set; }
+    public List<string>? GenericParameters { get; set; }
+    public bool IsGenericMethodDefinition { get; set; }
 }

--- a/Dosai/MethodsSlice.cs
+++ b/Dosai/MethodsSlice.cs
@@ -19,4 +19,5 @@ public class MethodsSlice
     public List<ConstructorInfo>? Constructors { get; set; }
     
     public CallGraph? CallGraph { get; set; }
+    public List<SourceAssemblyMapping>? SourceAssemblyMapping { get; set; }
 }

--- a/Dosai/Parameter.cs
+++ b/Dosai/Parameter.cs
@@ -4,4 +4,6 @@ public class Parameter
 {
     public string? Name { get; set; }
     public string? Type { get; set; }
+    public string? TypeFullName { get; set; }
+    public bool IsGenericParameter { get; set; }
 }

--- a/Dosai/PropertyInfo.cs
+++ b/Dosai/PropertyInfo.cs
@@ -19,4 +19,6 @@ public class PropertyInfo
     public List<string>? Implements { get; set; }
     public string? BaseType { get; set; }
     public List<string>? ImplementedInterfaces { get; set; }
+    public int MetadataToken { get; set; }
+    public string? TypeFullName { get; set; }
 }

--- a/Dosai/SourceAssemblyMapping.cs
+++ b/Dosai/SourceAssemblyMapping.cs
@@ -1,0 +1,94 @@
+namespace Depscan;
+
+/// <summary>
+/// Represents a mapping between a source code element and its compiled representation in an assembly.
+/// </summary>
+public class SourceAssemblyMapping
+{
+    /// <summary>
+    /// Gets or sets the unique identifier for the source element (e.g., "Namespace.Class.Member").
+    /// This corresponds to the Id used in MethodNode for source elements.
+    /// </summary>
+    public string? SourceId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the path to the source file.
+    /// </summary>
+    public string? SourcePath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the line number in the source file where the element is declared.
+    /// </summary>
+    public int SourceLineNumber { get; set; }
+
+    /// <summary>
+    /// Gets or sets the column number in the source file where the element is declared.
+    /// </summary>
+    public int SourceColumnNumber { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the unique signature of the source element.
+    /// Format: Namespace.ClassName.MemberName[[GenericParameters]]([ParameterTypes,...]):ReturnType (for methods/ctors)
+    ///         Namespace.ClassName.MemberName:Type (for fields/properties/events)
+    /// </summary>
+    public string? SourceSignature { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Metadata Token of the element as determined during source analysis.
+    /// This might be 0 if not available from Roslyn during analysis.
+    /// </summary>
+    public int SourceMetadataToken { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Metadata Token of the corresponding element found in the compiled assembly via reflection.
+    /// </summary>
+    public int AssemblyMetadataToken { get; set; }
+
+    /// <summary>
+    /// Gets or sets the full name of the assembly containing the compiled element.
+    /// </summary>
+    public string? AssemblyName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the module within the assembly containing the compiled element.
+    /// </summary>
+    public string? ModuleName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the unique identifier for the assembly element (e.g., "Namespace.Class.Member").
+    /// This could be constructed similarly to SourceId or based on reflection data.
+    /// </summary>
+    public string? AssemblyId { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the unique signature of the assembly element (as derived from reflection).
+    /// Format: Namespace.ClassName.MemberName[[GenericParameters]]([ParameterTypes,...]):ReturnType (for methods/ctors)
+    ///         Namespace.ClassName.MemberName:Type (for fields/properties/events)
+    /// </summary>
+    public string? AssemblySignature { get; set; }
+
+    /// <summary>
+    /// Gets or sets the type of member this mapping represents (Method, Property, Field, Event, Constructor).
+    /// </summary>
+    public string? MemberType { get; set; } // e.g., "Method", "Property"
+
+    /// <summary>
+    /// Gets or sets the name of the member.
+    /// </summary>
+    public string? MemberName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the class containing the member.
+    /// </summary>
+    public string? ClassName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the namespace of the member.
+    /// </summary>
+    public string? Namespace { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether a valid mapping was found based on signature matching.
+    /// </summary>
+    public bool IsMapped { get; set; }
+}


### PR DESCRIPTION
Problem. We currently do source and binary analysis separately. The question this PR tries (unsuccessfully) to answer is - what source contributed to what part in an assembly?

I learnt about `MetadataToken`, an integer assigned by the compiler to each entity within a .dll or .exe. This is now correctly captured. However, the compilation and semantic models from Roslyn are created before the actual compilation phase, so the token is always 0.

As a fallback, I tried adding method signature-based matching, which didn't work either. However, there is room for future improvements, so the PR is still useful.

Also added support for generics.

Attached is the enhanced output for dotnet-podcasts. Uncompressed it is around 238MB.

[dosai.json.zip](https://github.com/user-attachments/files/22299706/dosai.json.zip)

We can see that after all this complex analysis, we are matching just a couple of methods from source to assembly. I am hoping there will be new contributors willing to learn and help improve the tool.

```
"SourceAssemblyMapping": [
        {
            "SourceId": "ListenTogether.Infrastructure.ServiceCollectionsExtensions.AddInfrastructure(Microsoft.Extensions.DependencyInjection.IServiceCollection,Microsoft.Extensions.Configuration.IConfiguration):Microsoft.Extensions.DependencyInjection.IServiceCollection",
            "SourcePath": "src/Services/ListenTogether/ListenTogether.Infrastructure/ServiceCollectionsExtensions.cs",
            "SourceLineNumber": 11,
            "SourceColumnNumber": 9,
            "SourceMetadataToken": 0,
            "AssemblyMetadataToken": 100663346,
            "AssemblyName": "ServiceCollectionsExtensions.cs, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
            "ModuleName": "ServiceCollectionsExtensions.cs.exe",
            "AssemblyId": "ListenTogether.Infrastructure.ServiceCollectionsExtensions.AddInfrastructure(Microsoft.Extensions.DependencyInjection.IServiceCollection,Microsoft.Extensions.Configuration.IConfiguration):Microsoft.Extensions.DependencyInjection.IServiceCollection",
            "MemberType": "Method",
            "MemberName": "AddInfrastructure",
            "ClassName": "ServiceCollectionsExtensions",
            "Namespace": "ListenTogether.Infrastructure",
            "IsMapped": true
        },
        {
            "SourceId": "ListenTogether.Application.ServiceCollectionsExtensions.AddApplication(Microsoft.Extensions.DependencyInjection.IServiceCollection):Microsoft.Extensions.DependencyInjection.IServiceCollection",
            "SourcePath": "src/Services/ListenTogether/ListenTogether.Application/ServiceCollectionsExtensions.cs",
            "SourceLineNumber": 10,
            "SourceColumnNumber": 5,
            "SourceMetadataToken": 0,
            "AssemblyMetadataToken": 100663306,
            "AssemblyName": "ServiceCollectionsExtensions.cs, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
            "ModuleName": "ServiceCollectionsExtensions.cs.exe",
            "AssemblyId": "ListenTogether.Application.ServiceCollectionsExtensions.AddApplication(Microsoft.Extensions.DependencyInjection.IServiceCollection):Microsoft.Extensions.DependencyInjection.IServiceCollection",
            "MemberType": "Method",
            "MemberName": "AddApplication",
            "ClassName": "ServiceCollectionsExtensions",
            "Namespace": "ListenTogether.Application",
            "IsMapped": true
        }
    ]
```
