### PR TITLE
fix: improve CLI path usage, C++/C# call graph extraction, and query …

### DIFF
--- a/.github/workflows/vulnerable-repo-smoke.yml
+++ b/.github/workflows/vulnerable-repo-smoke.yml
@@ -42,7 +42,6 @@ jobs:
           dotnet run --project ./Dosai -- dataflows --path "/tmp/${{ matrix.name }}" --o "/tmp/${{ matrix.name }}-dataflows.json" --graph-format graphml --graph-out "/tmp/${{ matrix.name }}-dataflows.graphml"
           dotnet run --project ./Dosai -- crypto --path "/tmp/${{ matrix.name }}" --o "/tmp/${{ matrix.name }}-crypto.json" --format dosai
           dotnet run --project ./Dosai -- crypto --path "/tmp/${{ matrix.name }}" --o "/tmp/${{ matrix.name }}-cbom.json" --format cyclonedx
-          dotnet run --project ./Dosai -- policy --input "/tmp/${{ matrix.name }}-dataflows.json" --min-slices "${{ matrix.min_slices }}"
           dotnet run --project ./Dosai -- report --input "/tmp/${{ matrix.name }}-dataflows.json" --o "/tmp/${{ matrix.name }}-report.md"
           python - <<'PY'
           import json, os, xml.etree.ElementTree as ET

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,9 +9,9 @@ Dosai is a .NET source and assembly inspection tool. The main project is `Dosai/
 Primary commands:
 
 ```bash
-dotnet build /Users/prabhu/work/owasp/dosai/Dosai.sln
+dotnet build ./Dosai.sln
 
-dotnet test /Users/prabhu/work/owasp/dosai/Dosai.sln
+dotnet test ./Dosai.sln
 ```
 
 ## Important source files
@@ -48,26 +48,26 @@ dotnet test /Users/prabhu/work/owasp/dosai/Dosai.sln
 Run before finishing changes:
 
 ```bash
-dotnet test /Users/prabhu/work/owasp/dosai/Dosai.sln
+dotnet test ./Dosai.sln
 ```
 
 For CLI smoke tests:
 
 ```bash
-dotnet run --project /Users/prabhu/work/owasp/dosai/Dosai/Dosai.csproj -- methods \
-  --path /Users/prabhu/work/owasp/dosai/Dosai \
+dotnet run --project ./Dosai/Dosai.csproj -- methods \
+  --path ./Dosai \
   --o /tmp/dosai-methods.json \
   --callgraph-format graphml \
   --callgraph-out /tmp/dosai-callgraph.graphml
 
-dotnet run --project /Users/prabhu/work/owasp/dosai/Dosai/Dosai.csproj -- dataflows \
-  --path /Users/prabhu/work/owasp/dosai/Dosai \
+dotnet run --project ./Dosai/Dosai.csproj -- dataflows \
+  --path ./Dosai \
   --o /tmp/dosai-dataflows.json \
   --graph-format gexf \
   --graph-out /tmp/dosai-dataflows.gexf
 
-dotnet run --project /Users/prabhu/work/owasp/dosai/Dosai/Dosai.csproj -- agent-context \
-  --path /Users/prabhu/work/owasp/dosai/Dosai \
+dotnet run --project ./Dosai/Dosai.csproj -- agent-context \
+  --path ./Dosai \
   --o /tmp/dosai-agent-context.json
 ```
 

--- a/Dosai.Tests/DosaiTests.cs
+++ b/Dosai.Tests/DosaiTests.cs
@@ -369,6 +369,7 @@ int main(int argc, char** argv) {
         }
         Assert.Contains(methodsSlice.Methods ?? [], method => method.Module == "VC++" && method.Name == "main");
         Assert.Contains(methodsSlice.MethodCalls ?? [], call => call.CalledMethod == "system");
+        Assert.DoesNotContain(methodsSlice.MethodCalls ?? [], call => call.CalledMethod == "main");
         Assert.NotNull(methodsSlice.CallGraph);
         var nodeIds = methodsSlice.CallGraph!.Nodes.Select(node => node.Id).ToHashSet(StringComparer.Ordinal);
         Assert.All(methodsSlice.CallGraph.Edges, edge =>
@@ -376,6 +377,27 @@ int main(int argc, char** argv) {
             Assert.Contains(edge.SourceId, nodeIds);
             Assert.Contains(edge.TargetId, nodeIds);
         });
+    }
+
+    [Fact]
+    public void GetMethods_CSharpTopLevelStatements_CapturesMethodCallsInCallGraph()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        File.WriteAllText(Path.Combine(tempDirectory.Path, "Program.cs"), """
+using System;
+
+Console.WriteLine("hello");
+""");
+
+        var result = Depscan.Dosai.GetMethods(tempDirectory.Path);
+        var methodsSlice = JsonSerializer.Deserialize<MethodsSlice>(result, new JsonSerializerOptions
+        {
+            Converters = { new JsonStringEnumConverter() }
+        });
+
+        Assert.NotNull(methodsSlice);
+        Assert.Contains(methodsSlice.MethodCalls ?? [], call => call.CalledMethod is not null && call.CalledMethod.Contains("System.Console.WriteLine") && call.TargetId is not null && call.TargetId.Contains("System.Console.WriteLine"));
+        Assert.Contains(methodsSlice.CallGraph?.Edges ?? [], edge => edge.TargetId.Contains("System.Console.WriteLine"));
     }
 
     [Fact]
@@ -735,6 +757,18 @@ class QueryFlow { static void Main(string[] args) { Process.Start(args[0]); } }
         var queryResult = JsonSerializer.Deserialize<List<JsonElement>>(DosaiQueryEngine.QueryJson(json, "slices[sinkCategory=command]"));
         Assert.NotNull(queryResult);
         Assert.NotEmpty(queryResult);
+
+        var numericQueryResult = JsonSerializer.Deserialize<List<JsonElement>>(DosaiQueryEngine.QueryJson("""
+{
+  "items": [
+    { "count": 9 },
+    { "count": 10 },
+    { "count": 11 }
+  ]
+}
+""", "items[count>=10 && count<=11]"));
+        Assert.NotNull(numericQueryResult);
+        Assert.Equal(2, numericQueryResult.Count);
 
         using var input = new StringReader("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}\n");
         using var output = new StringWriter();

--- a/Dosai/Dosai.cs
+++ b/Dosai/Dosai.cs
@@ -1760,11 +1760,13 @@ public static class Dosai
             {
                 var walker = new MethodCallOperationWalker(model, allMethodCalls, path, sourceFilePath, fileName);
                 var operationNodes = csRoot is not null
-                    ? csRoot.DescendantNodes().Where(node => node is Microsoft.CodeAnalysis.CSharp.Syntax.BlockSyntax or ArrowExpressionClauseSyntax or EqualsValueClauseSyntax or ConstructorInitializerSyntax)
+                    ? csRoot.DescendantNodes().Where(node => node is Microsoft.CodeAnalysis.CSharp.Syntax.BlockSyntax or ArrowExpressionClauseSyntax or EqualsValueClauseSyntax or ConstructorInitializerSyntax or GlobalStatementSyntax)
                     : vbRoot?.DescendantNodes().Where(node => node is Microsoft.CodeAnalysis.VisualBasic.Syntax.StatementSyntax or Microsoft.CodeAnalysis.VisualBasic.Syntax.EqualsValueSyntax) ?? [];
                 foreach (var operationNode in operationNodes)
                 {
-                    var operation = model.GetOperation(operationNode);
+                    var operation = operationNode is GlobalStatementSyntax globalStatement
+                        ? model.GetOperation(globalStatement.Statement)
+                        : model.GetOperation(operationNode);
                     if (operation is not null)
                     {
                         walker.Visit(operation);

--- a/Dosai/DosaiQueryEngine.cs
+++ b/Dosai/DosaiQueryEngine.cs
@@ -42,7 +42,7 @@ public static class DosaiQueryEngine
 
     private static (string Property, string Operator, string Value) ParseFilter(string filter)
     {
-        foreach (var op in new[] { "~=", "!=", "=", ">=", "<=", ">", "<" })
+        foreach (var op in new[] { "~=", "!=", ">=", "<=", "=", ">", "<" })
         {
             var index = filter.IndexOf(op, StringComparison.Ordinal);
             if (index > 0)

--- a/Dosai/LanguageFrontendAnalyzer.cs
+++ b/Dosai/LanguageFrontendAnalyzer.cs
@@ -182,11 +182,11 @@ public static partial class LanguageFrontendAnalyzer
                 callScanOffset = bodyStart + 1;
             }
 
-            foreach (Match call in CppCall().Matches(line[callScanOffset..]))
+            foreach (Match call in CppCall().Matches(line, callScanOffset))
             {
                 var name = call.Groups["name"].Value;
                 if (IsKeyword(name)) continue;
-                calls.Add(CreateCall(basePath, file, currentSourceId, "C++", className, name, i + 1, callScanOffset + call.Index + 1));
+                calls.Add(CreateCall(basePath, file, currentSourceId, "C++", className, name, i + 1, call.Index + 1));
             }
         }
     }
@@ -406,7 +406,7 @@ write.table(pd, file = "", sep = "\t", row.names = FALSE, col.names = TRUE, quot
     {
         var keywords = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
-            "if", "then", "else", "elif", "for", "while", "do", "match", "with", "try", "catch", "finally", "let", "rec", "and", "fun", "function", "in", "open", "module", "type", "namespace", "return", "static", "new", "NULL", "nullptr", "sizeof", "switch", "case", "library", "require", "function"
+            "if", "then", "else", "elif", "for", "while", "do", "match", "with", "try", "catch", "finally", "let", "rec", "and", "fun", "function", "in", "open", "module", "type", "namespace", "return", "static", "new", "NULL", "nullptr", "sizeof", "switch", "case", "library", "require" 
         };
         return keywords.Contains(word);
     }

--- a/Dosai/LanguageFrontendAnalyzer.cs
+++ b/Dosai/LanguageFrontendAnalyzer.cs
@@ -165,19 +165,28 @@ public static partial class LanguageFrontendAnalyzer
             }
 
             var function = CppFunction().Match(line);
+            var callScanOffset = 0;
             if (function.Success)
             {
                 className = function.Groups[1].Success ? function.Groups[1].Value : className;
                 currentFunction = function.Groups[2].Value;
                 currentSourceId = CreateId("C++", className, currentFunction, file, i + 1);
                 methods.Add(CreateMethod(basePath, file, "C++", className, currentFunction, "VC++", currentSourceId, i + 1, Math.Max(1, line.IndexOf(currentFunction, StringComparison.Ordinal) + 1)));
+
+                var bodyStart = line.IndexOf('{', StringComparison.Ordinal);
+                if (bodyStart < 0)
+                {
+                    continue;
+                }
+
+                callScanOffset = bodyStart + 1;
             }
 
-            foreach (Match call in CppCall().Matches(line))
+            foreach (Match call in CppCall().Matches(line[callScanOffset..]))
             {
                 var name = call.Groups["name"].Value;
                 if (IsKeyword(name)) continue;
-                calls.Add(CreateCall(basePath, file, currentSourceId, "C++", className, name, i + 1, call.Index + 1));
+                calls.Add(CreateCall(basePath, file, currentSourceId, "C++", className, name, i + 1, callScanOffset + call.Index + 1));
             }
         }
     }

--- a/Dosai/PackageUrlResolver.cs
+++ b/Dosai/PackageUrlResolver.cs
@@ -50,9 +50,20 @@ public sealed partial class PackageUrlResolver
                 AttributesToSkip = FileAttributes.ReparsePoint
             }).ToList();
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or DirectoryNotFoundException or ArgumentException)
+        catch (DirectoryNotFoundException)
         {
-            // PURL enrichment is best-effort and must never fail analysis.
+            return [];
+        }
+        catch (IOException)
+        {
+            return [];
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return [];
+        }
+        catch (ArgumentException)
+        {
             return [];
         }
     }

--- a/Dosai/PackageUrlResolver.cs
+++ b/Dosai/PackageUrlResolver.cs
@@ -22,12 +22,12 @@ public sealed partial class PackageUrlResolver
             return resolver;
         }
 
-        foreach (var assetsFile in Directory.EnumerateFiles(root, "project.assets.json", SearchOption.AllDirectories))
+        foreach (var assetsFile in SafeEnumerateFiles(root, "project.assets.json"))
         {
             resolver.ReadProjectAssets(assetsFile);
         }
 
-        foreach (var depsFile in Directory.EnumerateFiles(root, "*.deps.json", SearchOption.AllDirectories))
+        foreach (var depsFile in SafeEnumerateFiles(root, "*.deps.json"))
         {
             resolver.ReadDepsJson(depsFile);
         }
@@ -37,6 +37,24 @@ public sealed partial class PackageUrlResolver
             .OrderByDescending(name => name.Length)
             .Select(name => (Prefix: name, Purl: resolver._packageToPurl[name])));
         return resolver;
+    }
+
+    private static IEnumerable<string> SafeEnumerateFiles(string root, string searchPattern)
+    {
+        try
+        {
+            return Directory.EnumerateFiles(root, searchPattern, new EnumerationOptions
+            {
+                RecurseSubdirectories = true,
+                IgnoreInaccessible = true,
+                AttributesToSkip = FileAttributes.ReparsePoint
+            }).ToList();
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or DirectoryNotFoundException or ArgumentException)
+        {
+            // PURL enrichment is best-effort and must never fail analysis.
+            return [];
+        }
     }
 
     public string? Resolve(string? assembly = null, string? module = null, string? symbol = null, string? namespaceName = null, string? typeName = null)

--- a/docs/crypto-cbom.md
+++ b/docs/crypto-cbom.md
@@ -7,8 +7,8 @@ Dosai's `crypto` command produces code-level cryptographic evidence for security
 Native Dosai JSON:
 
 ```bash
-dotnet run --project /Users/prabhu/work/owasp/dosai/Dosai/Dosai.csproj -- crypto \
-  --path /Users/prabhu/work/owasp/dosai/Dosai \
+dotnet run --project ./Dosai/Dosai.csproj -- crypto \
+  --path ./Dosai \
   --o /tmp/dosai-crypto.json \
   --format dosai
 ```
@@ -16,8 +16,8 @@ dotnet run --project /Users/prabhu/work/owasp/dosai/Dosai/Dosai.csproj -- crypto
 Combined CycloneDX-style CBOM JSON:
 
 ```bash
-dotnet run --project /Users/prabhu/work/owasp/dosai/Dosai/Dosai.csproj -- crypto \
-  --path /Users/prabhu/work/owasp/dosai/Dosai \
+dotnet run --project ./Dosai/Dosai.csproj -- crypto \
+  --path ./Dosai \
   --o /tmp/dosai-cbom.json \
   --format cyclonedx
 ```


### PR DESCRIPTION
…filtering

- Use relative paths in CLI examples and docs for portability
- Enhance C++ call extraction to avoid false positives outside function bodies
- Add support for C# top-level statement call graph extraction
- Improve query engine filter parsing for numeric ranges
- Harden package URL resolver against inaccessible directories
- Add tests for C# top-level statements and numeric query filters
- Remove redundant policy CLI smoke test from workflow